### PR TITLE
fix installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ you should use [looppointer](https://github.com/kyoh86/looppointer).
 go:
 
 ```console
-$ go get github.com/kyoh86/exportloopref
+$ go get github.com/kyoh86/exportloopref/cmd/exportloopref
 ```
 
 [homebrew](https://brew.sh/):


### PR DESCRIPTION
Hello, thanks for an awesome linter. Without this change tool won't be installed to Go bin dir (the same for looppointer btw).