### PR TITLE
Introduce flag to warn on passing pointer to function

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,44 @@ func printp(p *int) {
 }
 ```
 
+## Flags
+
+If you would like exportloopref to be slightly more sensitive, in particular
+to false negatives of Class 1 above, you can pass the `-disallowFuncs` flag.
+This makes passing pointers to loop variables into any non-print function a
+diagnostic.
+
+```go
+package main
+
+import "fmt"
+
+type List []*int
+
+func (l *List) AppendP(p *int) {
+	*l = append(*l, p)
+}
+
+func main() {
+	list := List{}
+
+	println("loop expect exporting 10, 11, 12, 13")
+	for _, p := range []int{10, 11, 12, 13} {
+		fmt.Println(&p)  // not a diagnositc
+		list.AppendP(&p) // want "exporting a pointer for the loop variable p"
+	}
+
+	println(`array expecting "10, 11, 12, 13" but "13, 13, 13, 13"`)
+	for _, p := range ([]*int)(list) {
+		printp(p)
+	}
+}
+
+func printp(p *int) {
+	println(*p)
+}
+```
+
 ## Install
 
 go:

--- a/exportloopref_test.go
+++ b/exportloopref_test.go
@@ -46,3 +46,9 @@ func TestDepPointer(t *testing.T) {
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, exportloopref.Analyzer, "deeppointer")
 }
+
+func TestFuncs(t *testing.T) {
+	exportloopref.DisallowFuncs = true
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, exportloopref.Analyzer, "funcs")
+}

--- a/testdata/src/funcs/funcs.go
+++ b/testdata/src/funcs/funcs.go
@@ -1,0 +1,28 @@
+package main
+
+import "fmt"
+
+type List []*int
+
+func (l *List) AppendP(p *int) {
+	*l = append(*l, p)
+}
+
+func main() {
+	list := List{}
+
+	println("loop expect exporting 10, 11, 12, 13")
+	for _, p := range []int{10, 11, 12, 13} {
+		fmt.Println(&p)  // not a diagnositc
+		list.AppendP(&p) // want "exporting a pointer for the loop variable p"
+	}
+
+	println(`array expecting "10, 11, 12, 13" but "13, 13, 13, 13"`)
+	for _, p := range ([]*int)(list) {
+		printp(p)
+	}
+}
+
+func printp(p *int) {
+	println(*p)
+}


### PR DESCRIPTION
Adds a new flag `-disallowFuncs` which causes exportloopref to
emit a diagnostic if a reference to the loop variable is passed
to any function other than some explicitly allowed functions
(namely, functions in the `fmt` package, and the `print` and
`println` built-ins).

Also adds a test for this flag and its behavior, and updates
documentation to point users to the flag.