### PR TITLE
Using go install instead of go get to install an executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ func printp(p *int) {
 go:
 
 ```console
-$ go get github.com/kyoh86/exportloopref/cmd/exportloopref
+$ go install github.com/kyoh86/exportloopref/cmd/exportloopref@master
 ```
 
 [homebrew](https://brew.sh/):


### PR DESCRIPTION
Since go 1.18, go install is preferred to install an executable.

https://go.dev/doc/go-get-install-deprecation